### PR TITLE
Don't publish 0 byte files to s3

### DIFF
--- a/gobblin-core/src/main/java/gobblin/publisher/BaseS3Publisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/BaseS3Publisher.java
@@ -57,6 +57,9 @@ public abstract class BaseS3Publisher extends BaseDataPublisher {
   public abstract void publishMetadata(Collection<? extends WorkUnitState> states) throws IOException;
 
   protected void sendS3Data(BucketAndKey bk, InputStream is, long contentLength) throws IOException {
+    if (contentLength == 0) {
+      return;
+    }
     // get config parameters
     String awsAccessKey = this.getState().getProp(ConfigurationKeys.AWS_ACCESS_KEY);
     String awsSecretKey = this.getState().getProp(ConfigurationKeys.AWS_SECRET_KEY);


### PR DESCRIPTION
This is to prevent our s3 bucket from getting spammed with 0 byte keys. Will be especially useful in stage, where we won't have very much data flowing through this thing.