### PR TITLE
Feature/base s3 publisher

### DIFF
--- a/gobblin-core/src/main/java/gobblin/publisher/BatchKafkaData.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/BatchKafkaData.java
@@ -34,8 +34,8 @@ import java.util.Map;
  * @author akshay@nerdwallet.com
  */
 class BatchKafkaData {
-  // Cap the Kafka file size to 5 GB
-  private static final long MAX_KAFKA_FILE_SIZE = 5L * 1000000000L;
+  // Cap the Kafka file size to .5 GB
+  private static final long MAX_KAFKA_FILE_SIZE = 500L * 1000000L;
 
   /**
    * Batches all Kafka for one partition for each branch and returns a mapping from

--- a/gobblin-core/src/main/java/gobblin/publisher/KafkaS3Publisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/KafkaS3Publisher.java
@@ -77,8 +77,7 @@ public class KafkaS3Publisher extends BaseS3Publisher {
     String topic = StringUtils.join(arr1, "-");
     int prefix = new Random(System.nanoTime()).nextInt(s3Partitions);
     return String.format(
-            "%d/%s/%s",
-            prefix,
+            "%s/%s",
             topic,
             new SimpleDateFormat("yyyy/MM/dd/HH").format(new Date())
     );


### PR DESCRIPTION
Decreasing the S3 filesize due to a timeout I saw when uploading a 4.9 gb file. Amazon recommends using a multipart uploader for files bigger than 100 mb (but since we can't arbitrarily partition our files, we will manually partition them at 500 mb).

Also removed the s3 key prefix after our discussion with Wyatt/Shrikanth on Friday.