### PR TITLE
Bugfix/upload small files

### DIFF
--- a/gobblin-core/src/main/java/gobblin/publisher/BaseS3Publisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/BaseS3Publisher.java
@@ -218,6 +218,8 @@ public abstract class BaseS3Publisher extends BaseDataPublisher {
           }
           doAppend(f, g);
           i++;
+        } else {
+          return updatedFiles;
         }
       }
     }

--- a/gobblin-core/src/main/java/gobblin/publisher/BaseS3Publisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/BaseS3Publisher.java
@@ -210,17 +210,13 @@ public abstract class BaseS3Publisher extends BaseDataPublisher {
       }
       updatedFiles.add(fname);
       i++;
-      while (f.length() < PART_SIZE) {
-        if (i < files.size()) {
-          File g = new File(files.get(i));
-          if (g.length() == 0) {
-            return updatedFiles;
-          }
-          doAppend(f, g);
-          i++;
-        } else {
+      while (f.length() < PART_SIZE && i < files.size()) {
+        File g = new File(files.get(i));
+        if (g.length() == 0) {
           return updatedFiles;
         }
+        doAppend(f, g);
+        i++;
       }
     }
     return updatedFiles;


### PR DESCRIPTION
Fixes a bug where the inner while loop never terminates in the case that the last file is too small. One solution was to put an else after the original conditional which would cause the function to return, but I decided to add an additional condition to the while loop since I think its slightly clearer. 

Going to merge so that I can run a test tonight and have results tomorrow. Just wanna PR this so @eogren and @vikarmic can laugh at my carelessness (but actually just so you guys know what the bug was).