### PR TITLE
Updating file naming system for S3

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -455,7 +455,7 @@ public class ConfigurationKeys {
   public static final String S3_TIMESTAMP_PLACEHOLDER = "{timestamp}";
 
   /**
-   * If set to true, the publisher will
+   * If set to true, the publisher will append all files in the job together. Otherwise, it ships them back 1:1
    */
   public static final String S3_PUBLISHER_APPEND = "aws.s3.publisher.append";
   public static final boolean DEFAULT_S3_PUBLISHER_APPEND = true;

--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -441,6 +441,21 @@ public class ConfigurationKeys {
   public static final String DEFAULT_S3_SOURCE_DATE_PLACEHOLDER = "{source-date}";
   public static final String S3_SOURCE_DATE_OFFSET = "aws.s3.source.date.offset";
   public static final int DEFAULT_S3_SOURCE_DATE_OFFSET = -1;
+  /**
+   * The number of days to look backwards in time to propagate any slower changes.
+   * <p/>
+   * This allows a user to set the number of days they want to look back beyond the date offset. For example, if the
+   * system is set up with an offset of -1 and a lookback of 2, and the current date is June 19th, the system will
+   * check the S3 source for objects published June 18th, but also will look for any files added to "directories"
+   * from the 17th and 16th for changes.
+   * <p/>
+   * This is useful if you have systems with slow/eventual propagation, as it allows your system to process data as
+   * it comes in - both a mixture of real-time and delayed inputs.
+   * <p/>
+   * The value should be an integer greater than or equal to 0, representing the number of days to look backwards.
+   */
+  public static final String S3_SOURCE_DATE_LOOKBACK = "aws.s3.source.date.lookback";
+  public static final int DEFAULT_S3_SOURCE_DATE_LOOKBACK = 1;
 
   // Settings and defaults for the now keyword
   public static final String S3_PUBLISHER_DATE_PATTERN = "aws.s3.publisher.date.pattern";

--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -433,21 +433,45 @@ public class ConfigurationKeys {
   public static final String S3_PUBLISHER_BUCKET = "aws.s3.publisher.bucket";
   public static final String S3_PUBLISHER_PATH = "aws.s3.publisher.path";
   public static final String S3_PARTITIONS = "aws.s3.partitions";
-  public static final String S3_DATE_PATTERN = "aws.s3.date.pattern";
-  public static final String DEFAULT_S3_DATE_PATTERN = "yyyy/MM/dd";
-  public static final String S3_DATE_PLACEHOLDER = "aws.s3.date.placeholder";
-  public static final String DEFAULT_S3_DATE_PLACEHOLDER = "{date}";
+
+  // Settings and defaults for the date keyword
+  public static final String S3_SOURCE_DATE_PATTERN = "aws.s3.source.date.pattern";
+  public static final String DEFAULT_S3_SOURCE_DATE_PATTERN = "yyyy/MM/dd";
+  public static final String S3_SOURCE_DATE_PLACEHOLDER = "aws.s3.source.date.placeholder";
+  public static final String DEFAULT_S3_SOURCE_DATE_PLACEHOLDER = "{source-date}";
+  public static final String S3_SOURCE_DATE_OFFSET = "aws.s3.source.date.offset";
+  public static final int DEFAULT_S3_SOURCE_DATE_OFFSET = -1;
+
+  // Settings and defaults for the now keyword
+  public static final String S3_PUBLISHER_DATE_PATTERN = "aws.s3.publisher.date.pattern";
+  public static final String DEFAULT_S3_PUBLISHER_DATE_PATTERN = "yyyy/MM/dd";
+  public static final String S3_PUBLISHER_DATE_PLACEHOLDER = "aws.s3.publisher.date.placeholder";
+  public static final String DEFAULT_S3_PUBLISHER_DATE_PLACEHOLDER = "{publisher-date}";
+  public static final String S3_PUBLISHER_DATE_OFFSET = "aws.s3.publisher.date.offset";
+  public static final int DEFAULT_S3_PUBLISHER_DATE_OFFSET = 0;
+
+  public static final String S3_TIMESTAMP_PATTERN = "aws.s3.timestamp.pattern";
+  public static final String DEFAULT_S3_TIMESTAMP_PATTERN = "yyyyMMdd-HHmmss";
+  public static final String S3_TIMESTAMP_PLACEHOLDER = "{timestamp}";
+
+  /**
+   * If set to true, the publisher will
+   */
+  public static final String S3_PUBLISHER_APPEND = "aws.s3.publisher.append";
+  public static final boolean DEFAULT_S3_PUBLISHER_APPEND = true;
   public static final String S3_PATH_DELIMITER = "aws.s3.path.delimiter";
   public static final String DEFAULT_S3_PATH_DELIMITER = "/";
-  public static final String S3_DATE_OFFSET = "aws.s3.date.offset";
-  public static final int DEFAULT_S3_DATE_OFFSET = -1;
+
   /**
    * The format of the file to write to S3.
    * If this is not set, the original filename is used.
    * <p/>
    * Can contain the following placeholders:
-   * {counter} - an integer counter (guarantees unique keying)
-   * {date} - the current date (/ will be removed)
+   * {counter} - an integer counter of files in run (does NOT guarantee unique keying - doesn't check existing keys)
+   * <p/>
+   * {@link ConfigurationKeys#S3_SOURCE_DATE_PLACEHOLDER}
+   * <p/>
+   * {@link ConfigurationKeys#DEFAULT_S3_PUBLISHER_DATE_PLACEHOLDER}
    */
   public static final String S3_PUBLISHER_FILENAME_FORMAT = "aws.s3.publisher.filename.format";
 }

--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -46,13 +46,15 @@ dependencies {
   }
 
   if (System.getenv("GOBBLIN_LOCAL_JAR_LOCATION") != null) {
-    compile fileTree(dir: System.getenv("GOBBLIN_LOCAL_JAR_LOCATION"), include: '*.jar')
+    compile(fileTree(dir: System.getenv("GOBBLIN_LOCAL_JAR_LOCATION"), include: '*.jar')) {
+      transitive = true
+    }
   }
 
   testCompile externalDependency.testng
 }
 
-configurations { compile { transitive = true } }
+configurations { compile { transitive = false } }
 
 test {
   useTestNG () { excludeGroups 'ignore' }

--- a/gobblin-core/src/main/java/gobblin/publisher/SimpleS3Publisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/SimpleS3Publisher.java
@@ -59,7 +59,7 @@ public class SimpleS3Publisher extends BaseS3Publisher {
       throws IOException {
     String s3Bucket = this.getState().getProp(ConfigurationKeys.S3_PUBLISHER_BUCKET);
     String s3Path = this.getState().getProp(ConfigurationKeys.S3_PUBLISHER_PATH);
-    s3Path = S3Utils.checkAndReplaceDates(this.getState(), s3Path);
+    s3Path = S3Utils.checkAndReplaceDatePlaceholders(this.getState(), s3Path);
 
     boolean append = this.getState().getPropAsBoolean(ConfigurationKeys.S3_PUBLISHER_APPEND,
         ConfigurationKeys.DEFAULT_S3_PUBLISHER_APPEND);
@@ -84,7 +84,7 @@ public class SimpleS3Publisher extends BaseS3Publisher {
     ArrayList<String> writerFileNames = new ArrayList<String>();
 
     String s3Filename = generateObjectName(this.getState(), 0);
-    s3Path = S3Utils.checkAndReplaceDates(this.getState(), s3Path);
+    s3Path = S3Utils.checkAndReplaceDatePlaceholders(this.getState(), s3Path);
 
     for (WorkUnitState state : states) {
       for (int i = 0; i < this.numBranches; i++) {
@@ -118,7 +118,7 @@ public class SimpleS3Publisher extends BaseS3Publisher {
             state.getProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FINAL_OUTPUT_PATH, i));
         writerFileNames.add(writerFileName);
 
-        s3Path = S3Utils.checkAndReplaceDates(this.getState(), s3Path);
+        s3Path = S3Utils.checkAndReplaceDatePlaceholders(this.getState(), s3Path);
         String s3Filename = generateObjectName(state, counter++);
 
         this.sendS3Data(i, new BucketAndKey(s3Bucket, s3Path + s3Filename), writerFileNames);
@@ -144,7 +144,7 @@ public class SimpleS3Publisher extends BaseS3Publisher {
     String filenameFormat = state.getProp(ConfigurationKeys.S3_PUBLISHER_FILENAME_FORMAT);
     if (filenameFormat != null) {
       // If we use a filename format, replace out any date placeholders ({date},{now})
-      filenameFormat = S3Utils.checkAndReplaceDates(state, filenameFormat);
+      filenameFormat = S3Utils.checkAndReplaceDatePlaceholders(state, filenameFormat);
 
       // Replace the counter placeholder, if any
       filenameFormat = filenameFormat.replace("{counter}", Integer.toString(counter));

--- a/gobblin-core/src/main/java/gobblin/publisher/SimpleS3Publisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/SimpleS3Publisher.java
@@ -16,8 +16,6 @@ import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
 import gobblin.util.ForkOperatorUtils;
 import gobblin.util.S3Utils;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,9 +65,9 @@ public class SimpleS3Publisher extends BaseS3Publisher {
         ConfigurationKeys.DEFAULT_S3_PUBLISHER_APPEND);
 
     if (append) {
-      publishDataAsGroup(states, s3Bucket, s3Path);
+      batchPublishData(states, s3Bucket, s3Path);
     } else {
-      publishDataSeparately(states, s3Bucket, s3Path);
+      publishData(states, s3Bucket, s3Path);
     }
   }
 
@@ -81,7 +79,7 @@ public class SimpleS3Publisher extends BaseS3Publisher {
    * @param s3Path The S3 path to publish to (raw)
    * @throws IOException
    */
-  private void publishDataAsGroup(Collection<? extends WorkUnitState> states, String s3Bucket, String s3Path)
+  private void batchPublishData(Collection<? extends WorkUnitState> states, String s3Bucket, String s3Path)
       throws IOException {
     ArrayList<String> writerFileNames = new ArrayList<String>();
 
@@ -110,7 +108,7 @@ public class SimpleS3Publisher extends BaseS3Publisher {
    * @param s3Path The S3 path to publish to (raw)
    * @throws IOException
    */
-  private void publishDataSeparately(Collection<? extends WorkUnitState> states, String s3Bucket, String s3Path)
+  private void publishData(Collection<? extends WorkUnitState> states, String s3Bucket, String s3Path)
       throws IOException {
     int counter = 0;  // for filename counting
     for (WorkUnitState state : states) {

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/s3/S3FsHelper.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/s3/S3FsHelper.java
@@ -103,18 +103,14 @@ public class S3FsHelper implements FileBasedHelper {
   public List<String> ls(String path)
       throws FileBasedHelperException {
     try {
-      List<String> objectKeys = Lists.newArrayList();
-      for (String s3Path : s3Paths) {
-        objectKeys.addAll(recursivelyGetObjectKeys(s3Path));
-        if (objectKeys.size() == 0) {
-          LOG.warn("S3 bucket/path was empty, no results found.");
-          LOG.warn("S3 Bucket: " + s3Bucket);
-          LOG.warn("S3 Path: " + s3Path);
-        } else {
-          LOG.info("Found " + objectKeys.size() + " S3 objects!");
-        }
+      List<String> objectKeys = recursivelyGetObjectKeys(path);
+      if (objectKeys.size() == 0) {
+        LOG.warn("S3 bucket/path was empty, no results found.");
+        LOG.warn("S3 Bucket: " + s3Bucket);
+        LOG.warn("S3 Path: " + path);
+      } else {
+        LOG.info("Found " + objectKeys.size() + " S3 objects!");
       }
-
       return objectKeys;
     } catch (Exception e) {
       // TODO better exception finding

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/s3/S3FsHelper.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/s3/S3FsHelper.java
@@ -18,27 +18,14 @@ import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.google.common.collect.Lists;
-import com.jcraft.jsch.ChannelSftp;
-import com.jcraft.jsch.ChannelSftp.LsEntry;
-import com.jcraft.jsch.JSch;
-import com.jcraft.jsch.JSchException;
-import com.jcraft.jsch.ProxyHTTP;
-import com.jcraft.jsch.Session;
-import com.jcraft.jsch.SftpException;
-import com.jcraft.jsch.SftpProgressMonitor;
-import com.jcraft.jsch.UserInfo;
 import gobblin.configuration.ConfigurationKeys;
-import gobblin.configuration.SourceState;
 import gobblin.configuration.State;
 import gobblin.source.extractor.filebased.FileBasedHelper;
 import gobblin.source.extractor.filebased.FileBasedHelperException;
 import gobblin.util.S3Utils;
-import java.io.BufferedReader;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,18 +40,19 @@ public class S3FsHelper implements FileBasedHelper {
   private State state;
   private AmazonS3 s3Client;
   private String s3Bucket;
-  private String s3Path;
+  private List<String> s3Paths;
 
   /**
    * Creates an S3 filesystem helper. This method creates and stores the Amazon S3 client, as well as fetches the
    * bucket that the source should be looking into.
-   * @param state
+   * @param state The state
    */
   public S3FsHelper(State state) {
     this.state = state;
 
     s3Client = new AmazonS3Client();
     s3Bucket = state.getProp(ConfigurationKeys.S3_SOURCE_BUCKET);
+    s3Paths = Lists.newArrayList();
   }
 
   /**
@@ -78,10 +66,15 @@ public class S3FsHelper implements FileBasedHelper {
    */
   @Override
   public void connect() {
-    s3Path = state.getProp(ConfigurationKeys.S3_SOURCE_PATH);
+    String path = state.getProp(ConfigurationKeys.S3_SOURCE_PATH);
+    int lookback = state.getPropAsInt(ConfigurationKeys.S3_SOURCE_DATE_LOOKBACK,
+        ConfigurationKeys.DEFAULT_S3_SOURCE_DATE_LOOKBACK);
 
-    // Replace the date if needed (if none found, s3Path is unaffected)
-    s3Path = S3Utils.checkAndReplaceDates(state, s3Path);
+    // Go through each day of possible lookback to find old logs that may not have been logged
+    while (lookback >= 0) {
+      // Replace the date if needed (if none found, s3Path is unaffected)
+      s3Paths.add(S3Utils.checkAndReplaceDatePlaceholders(state, path, lookback--));
+    }
   }
 
   /**
@@ -110,14 +103,18 @@ public class S3FsHelper implements FileBasedHelper {
   public List<String> ls(String path)
       throws FileBasedHelperException {
     try {
-      List<String> objectKeys = recursivelyGetObjectKeys(s3Path);
-      if (objectKeys.size() == 0) {
-        LOG.warn("S3 bucket/path was empty, no results found.");
-        LOG.warn("S3 Bucket: " + s3Bucket);
-        LOG.warn("S3 Path: " + s3Path);
-      } else {
-        LOG.info("Found " + objectKeys.size() + " S3 objects!");
+      List<String> objectKeys = Lists.newArrayList();
+      for (String s3Path : s3Paths) {
+        objectKeys.addAll(recursivelyGetObjectKeys(s3Path));
+        if (objectKeys.size() == 0) {
+          LOG.warn("S3 bucket/path was empty, no results found.");
+          LOG.warn("S3 Bucket: " + s3Bucket);
+          LOG.warn("S3 Path: " + s3Path);
+        } else {
+          LOG.info("Found " + objectKeys.size() + " S3 objects!");
+        }
       }
+
       return objectKeys;
     } catch (Exception e) {
       // TODO better exception finding
@@ -152,11 +149,11 @@ public class S3FsHelper implements FileBasedHelper {
       }
 
       // For each folder, replace what we have and recurse until we are out of wildcards
-      List<String> objectSummaries = Lists.newArrayList();
+      List<String> objectKeys = Lists.newArrayList();
       for (String folderPath : folders) {
-        objectSummaries.addAll(recursivelyGetObjectKeys(folderPath + pathParts[1]));
+        objectKeys.addAll(recursivelyGetObjectKeys(folderPath + pathParts[1]));
       }
-      return objectSummaries;
+      return objectKeys;
     }
 
     // Otherwise, return whatever our path is
@@ -165,16 +162,16 @@ public class S3FsHelper implements FileBasedHelper {
 
     // Fetch all the objects in the given bucket/path
     ObjectListing objectListing = s3Client.listObjects(listObjectRequest);
-    List<S3ObjectSummary> objectSummaries = objectListing.getObjectSummaries();
+    List<String> objectKeys = getObjectKeys(objectListing.getObjectSummaries());
 
     // We have to do this if there are a large number of objects in the given path
     // Create the workunits and add them immediately to reduce memory load
     while (objectListing.isTruncated()) {
       objectListing = s3Client.listNextBatchOfObjects(objectListing);
-      objectSummaries.addAll(objectListing.getObjectSummaries());
+      objectKeys.addAll(getObjectKeys(objectListing.getObjectSummaries()));
     }
 
-    return getObjectKeys(objectSummaries);
+    return objectKeys;
   }
 
   /**
@@ -195,7 +192,7 @@ public class S3FsHelper implements FileBasedHelper {
   public void close() {
   }
 
-  public String getS3Path() {
-    return this.s3Path;
+  public List<String> getS3Paths() {
+    return this.s3Paths;
   }
 }

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/s3/S3FsHelper.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/s3/S3FsHelper.java
@@ -81,7 +81,7 @@ public class S3FsHelper implements FileBasedHelper {
     s3Path = state.getProp(ConfigurationKeys.S3_SOURCE_PATH);
 
     // Replace the date if needed (if none found, s3Path is unaffected)
-    s3Path = S3Utils.checkAndReplaceDate(state, s3Path);
+    s3Path = S3Utils.checkAndReplaceDates(state, s3Path);
   }
 
   /**

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/s3/S3Source.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/s3/S3Source.java
@@ -10,22 +10,12 @@
  */
 package gobblin.source.extractor.extract.s3;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.ListObjectsRequest;
-import com.amazonaws.services.s3.model.ObjectListing;
-import com.amazonaws.services.s3.model.S3ObjectSummary;
-import com.google.common.collect.Lists;
 import gobblin.configuration.ConfigurationKeys;
-import gobblin.configuration.SourceState;
 import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
 import gobblin.source.extractor.Extractor;
 import gobblin.source.extractor.filebased.FileBasedHelperException;
 import gobblin.source.extractor.filebased.FileBasedSource;
-import gobblin.source.workunit.Extract;
-import gobblin.source.workunit.WorkUnit;
-import gobblin.util.S3Utils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,9 +31,9 @@ import org.slf4j.LoggerFactory;
  * If you want your S3 paths to contain a date, the {@link S3Source} will
  * automatically check for you.
  * Relevant date manipulation values are:
- * {@link ConfigurationKeys#S3_DATE_PATTERN} (the pattern to match),
- * {@link ConfigurationKeys#S3_DATE_PLACEHOLDER} (the placeholder in the jobfile path), and
- * {@link ConfigurationKeys#S3_DATE_OFFSET} (the number of days offset (relative to the current date)
+ * {@link ConfigurationKeys#S3_SOURCE_DATE_PATTERN} (the pattern to match),
+ * {@link ConfigurationKeys#S3_SOURCE_DATE_PLACEHOLDER} (the placeholder in the jobfile path), and
+ * {@link ConfigurationKeys#S3_SOURCE_DATE_OFFSET} (the number of days offset (relative to the current date)
  * <p/>
  * If you do not wish, defaults are set for those values
  * and your paths will be unaffected.

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/s3/S3Source.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/s3/S3Source.java
@@ -72,13 +72,19 @@ public class S3Source<S, D> extends FileBasedSource<S, D> {
   public List<String> getcurrentFsSnapshot(State state) {
     List<String> results = new ArrayList<String>();
     S3FsHelper s3FsHelper = (S3FsHelper) this.fsHelper;
-    String path = s3FsHelper.getS3Path();
+    List<String> paths = s3FsHelper.getS3Paths();
 
-    try {
-      LOG.info("Running ls command with input " + path);
-      results = this.fsHelper.ls(path);
-    } catch (FileBasedHelperException e) {
-      LOG.error("Not able to run ls command due to " + e.getMessage() + " will not pull any files", e);
+    for(String path : paths) {
+      try {
+        LOG.info("Running ls command with input " + path);
+        results.addAll(this.fsHelper.ls(path));
+      } catch (FileBasedHelperException e) {
+        LOG.error("ls command unsuccessful - " + e.getMessage() + " will not pull any files", e);
+      }
+    }
+
+    if(results.size() == 0) {
+      LOG.error("Either there were no new files or no files found in the specified path(s).");
     }
 
     return results;

--- a/gobblin-utility/src/main/java/gobblin/util/S3Utils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/S3Utils.java
@@ -11,10 +11,11 @@
 package gobblin.util;
 
 import gobblin.configuration.ConfigurationKeys;
-import gobblin.configuration.SourceState;
 import gobblin.configuration.State;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -23,31 +24,64 @@ import java.util.Calendar;
  * @author ahollenbach@nerdwallet.com
  */
 public class S3Utils {
+  private static final Logger LOG = LoggerFactory.getLogger(S3Utils.class);
 
   /**
    * If you want a your S3 path (or any string) to contain a date, you can replace it here
-   * The placeholder is what the source looks for in the path, and replaces it
-   * with the date (offset by S3_DATE_OFFSET), using the pattern to format it.
+   * The placeholder is what it looks for in the path, and replaces it
+   * with the date (offset by S3_*_DATE_OFFSET), using the pattern to format it.
    * <p/>
-   * If no date is matched in the path, nothing happens and it returns back
+   * If no dates are matched in the path, nothing happens and it returns back
    * the string unchanged.
+   * <p/>
+   * This also replaces timestamps if you have included that placeholder.
    *
    * @param state  The state
    * @param str A string possibly containing a date placeholder
    * @return the string with any date placeholders replaced with the specified date
    * pattern and offset.
    */
-  public static String checkAndReplaceDate(State state, String str) {
-    String placeholder =
-        state.getProp(ConfigurationKeys.S3_DATE_PLACEHOLDER, ConfigurationKeys.DEFAULT_S3_DATE_PLACEHOLDER);
-    String datePattern = state.getProp(ConfigurationKeys.S3_DATE_PATTERN, ConfigurationKeys.DEFAULT_S3_DATE_PATTERN);
-    // If set, 0 for today, -1 for yesterday, etc.
-    int dateOffset = state.getPropAsInt(ConfigurationKeys.S3_DATE_OFFSET, ConfigurationKeys.DEFAULT_S3_DATE_OFFSET);
+  public static String checkAndReplaceDates(State state, String str) {
+    // Replace any now placeholders
+    String publisherPlaceholder =
+        state.getProp(ConfigurationKeys.S3_PUBLISHER_DATE_PLACEHOLDER, ConfigurationKeys.DEFAULT_S3_PUBLISHER_DATE_PLACEHOLDER);
+    String publisherPattern =
+        state.getProp(ConfigurationKeys.S3_PUBLISHER_DATE_PATTERN, ConfigurationKeys.DEFAULT_S3_PUBLISHER_DATE_PATTERN);
+    str = replaceDate(str, publisherPlaceholder, publisherPattern, 0);
 
+
+    // Replace any of the date placeholders
+    String datePlaceholder =
+        state.getProp(ConfigurationKeys.S3_SOURCE_DATE_PLACEHOLDER, ConfigurationKeys.DEFAULT_S3_SOURCE_DATE_PLACEHOLDER);
+    String datePattern = state.getProp(ConfigurationKeys.S3_SOURCE_DATE_PATTERN, ConfigurationKeys.DEFAULT_S3_SOURCE_DATE_PATTERN);
+    // If set, 0 for today, -1 for yesterday, etc.
+    int dateOffset = state.getPropAsInt(ConfigurationKeys.S3_SOURCE_DATE_OFFSET, ConfigurationKeys.DEFAULT_S3_SOURCE_DATE_OFFSET);
+    str = replaceDate(str, datePlaceholder, datePattern, dateOffset);
+
+
+    // Replace any timestamp placeholders
+    String timestampPlaceholder = ConfigurationKeys.S3_TIMESTAMP_PLACEHOLDER;
+    String timestampPattern =
+        state.getProp(ConfigurationKeys.S3_TIMESTAMP_PATTERN, ConfigurationKeys.DEFAULT_S3_TIMESTAMP_PATTERN);
+    str = replaceDate(str, timestampPlaceholder, timestampPattern, 0);
+
+    return str;
+  }
+
+  /**
+   * Replaces a placeholder with the date using the pattern and offset supplied, relative to the current time.
+   *
+   * @param input An input string containing 0 or more of the datePlaceholder
+   * @param datePlaceholder A placeholder string to match on
+   * @param datePattern The pattern to use when formatting the date
+   * @param dateOffset The offset to the current time (0 for current, -1 for one day ago, etc.)
+   * @return The input with all of the given placeholder replaced with the date formatted as specified.
+   */
+  private static String replaceDate(String input, String datePlaceholder, String datePattern, int dateOffset) {
     SimpleDateFormat df = new SimpleDateFormat(datePattern);
     Calendar cal = Calendar.getInstance();
     cal.add(Calendar.DATE, dateOffset);
 
-    return str.replace(placeholder, df.format(cal.getTime()));
+    return input.replace(datePlaceholder, df.format(cal.getTime()));
   }
 }


### PR DESCRIPTION
- Separated out a source date and destination date
- Each can be configured separately
- Added a timestamp
- Removed global `transtive=true` setting for gobblin-core
- Allows you to batch all new logs together or separately

Transitive issue is continuation from #27.